### PR TITLE
add more logger options and remove golangci.com

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,8 +73,3 @@ run:
     - vendor/
   skip-files:
     - ./*_test.go
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.20.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
   - master
 
 matrix:
@@ -26,8 +27,14 @@ branches:
 before_install:
   - go get -u -v github.com/mattn/goveralls
 
+# golangci.com will be closed on 2020-04-15
+# https://medium.com/golangci/golangci-com-is-closing-d1fc1bd30e0e
+before_script:
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.23.8/install.sh | sh -s -- -b $GOPATH/bin v1.23.8
+
 script:
   - go vet
+  - golangci-lint run
   - test -z "$(go fmt ./...)" # fail if not formatted properly
   - go test -v -race -coverprofile=coverage.out -covermode=atomic -tags=unit ./...
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQLDB-Logger
 
-[![Build Status](https://travis-ci.com/simukti/sqldb-logger.svg)](https://travis-ci.com/simukti/sqldb-logger) [![Coverage Status](https://coveralls.io/repos/github/simukti/sqldb-logger/badge.svg)](https://coveralls.io/github/simukti/sqldb-logger) [![Go Report Card](https://goreportcard.com/badge/github.com/simukti/sqldb-logger)](https://goreportcard.com/report/github.com/simukti/sqldb-logger) [![GolangCI Status](https://golangci.com/badges/github.com/simukti/sqldb-logger.svg)](https://golangci.com/r/github.com/simukti/sqldb-logger) [![Documentation](https://godoc.org/github.com/simukti/sqldb-logger?status.svg)](http://godoc.org/github.com/simukti/sqldb-logger) [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://raw.githubusercontent.com/simukti/sqldb-logger/master/LICENSE.txt)
+[![Build Status](https://travis-ci.com/simukti/sqldb-logger.svg)](https://travis-ci.com/simukti/sqldb-logger) [![Coverage Status](https://coveralls.io/repos/github/simukti/sqldb-logger/badge.svg)](https://coveralls.io/github/simukti/sqldb-logger) [![Go Report Card](https://goreportcard.com/badge/github.com/simukti/sqldb-logger)](https://goreportcard.com/report/github.com/simukti/sqldb-logger) [![Documentation](https://godoc.org/github.com/simukti/sqldb-logger?status.svg)](http://godoc.org/github.com/simukti/sqldb-logger) [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://raw.githubusercontent.com/simukti/sqldb-logger/master/LICENSE.txt)
 
 A logger for Go SQL database driver without modify existing `*sql.DB` stdlib usage.
 
@@ -49,7 +49,7 @@ dsn := "username:passwd@tcp(mysqlserver:3306)/dbname?parseTime=true"
 db := sqldblogger.OpenDriver(dsn, &mysql.MySQLDriver{}, loggerAdapter) // db is still *sql.DB
 ``` 
 
-Without giving 4th argument to `OpenDriver`, it will use [default options](./options.go#L32-L49).
+Without giving 4th argument to `OpenDriver`, it will use [default options](./options.go#L37-L59).
 
 That's it. Use `db` object as usual.
 
@@ -79,6 +79,11 @@ db := sqldblogger.OpenDriver(
     sqldblogger.WithStatementIDFieldname("stm_id"), // default: stmt_id
     sqldblogger.WithTransactionIDFieldname("trx_id"), // default: tx_id
     sqldblogger.WithWrapResult(false), // default: true
+    sqldblogger.WithIncludeStartTime(true), // default: false
+    sqldblogger.WithStartTimeFieldname("start_time"), // default: start
+    sqldblogger.WithPreparerLevel(LevelDebug), // default: LevelInfo
+    sqldblogger.WithQueryerLevel(LevelDebug), // default: LevelInfo
+    sqldblogger.WithExecerLevel(LevelDebug), // default: LevelInfo
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQLDB-Logger
 
-[![Build Status](https://travis-ci.com/simukti/sqldb-logger.svg)](https://travis-ci.com/simukti/sqldb-logger) [![Coverage Status](https://coveralls.io/repos/github/simukti/sqldb-logger/badge.svg)](https://coveralls.io/github/simukti/sqldb-logger) [![Go Report Card](https://goreportcard.com/badge/github.com/simukti/sqldb-logger)](https://goreportcard.com/report/github.com/simukti/sqldb-logger) [![Documentation](https://godoc.org/github.com/simukti/sqldb-logger?status.svg)](http://godoc.org/github.com/simukti/sqldb-logger) [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://raw.githubusercontent.com/simukti/sqldb-logger/master/LICENSE.txt)
+[![Build Status](https://travis-ci.com/simukti/sqldb-logger.svg)](https://travis-ci.com/simukti/sqldb-logger) [![Coverage Status](https://coveralls.io/repos/github/simukti/sqldb-logger/badge.svg)](https://coveralls.io/github/simukti/sqldb-logger) [![Go Report Card](https://goreportcard.com/badge/github.com/simukti/sqldb-logger)](https://goreportcard.com/report/github.com/simukti/sqldb-logger) [![Documentation](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/simukti/sqldb-logger) [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://raw.githubusercontent.com/simukti/sqldb-logger/master/LICENSE.txt)
 
 A logger for Go SQL database driver without modify existing `*sql.DB` stdlib usage.
 

--- a/connection.go
+++ b/connection.go
@@ -27,7 +27,7 @@ type connection struct {
 func (c *connection) Begin() (driver.Tx, error) {
 	lvl, start, id := LevelDebug, time.Now(), c.logger.opt.uidGenerator.UniqueID()
 	logs := append(c.logData(), c.logger.withUID(c.logger.opt.txIDFieldname, id))
-	connTx, err := c.Conn.Begin() // nolint: staticcheck
+	connTx, err := c.Conn.Begin() // nolint // disable static check on deprecated driver method
 
 	if err != nil {
 		lvl = LevelError
@@ -40,7 +40,7 @@ func (c *connection) Begin() (driver.Tx, error) {
 
 // Prepare implements driver.Conn
 func (c *connection) Prepare(query string) (driver.Stmt, error) {
-	lvl, start, id := LevelInfo, time.Now(), c.logger.opt.uidGenerator.UniqueID()
+	lvl, start, id := c.logger.opt.preparerLevel, time.Now(), c.logger.opt.uidGenerator.UniqueID()
 	logs := append(c.logData(), c.logger.withQuery(query), c.logger.withUID(c.logger.opt.stmtIDFieldname, id))
 	driverStmt, err := c.Conn.Prepare(query)
 
@@ -94,7 +94,7 @@ func (c *connection) PrepareContext(ctx context.Context, query string) (driver.S
 		return nil, driver.ErrSkip
 	}
 
-	lvl, start, id := LevelInfo, time.Now(), c.logger.opt.uidGenerator.UniqueID()
+	lvl, start, id := c.logger.opt.preparerLevel, time.Now(), c.logger.opt.uidGenerator.UniqueID()
 	logs := append(c.logData(), c.logger.withQuery(query), c.logger.withUID(c.logger.opt.stmtIDFieldname, id))
 	driverStmt, err := driverPrep.PrepareContext(ctx, query)
 
@@ -129,13 +129,13 @@ func (c *connection) Ping(ctx context.Context) error {
 // Exec implements driver.Execer
 // Deprecated: use ExecContext() instead
 func (c *connection) Exec(query string, args []driver.Value) (driver.Result, error) {
-	driverExecer, ok := c.Conn.(driver.Execer) // nolint: staticcheck
+	driverExecer, ok := c.Conn.(driver.Execer) // nolint // disable static check on deprecated driver method
 	if !ok {
 		return nil, driver.ErrSkip
 	}
 
 	logs := append(c.logData(), c.logger.withQuery(query), c.logger.withArgs(args))
-	lvl, start := LevelInfo, time.Now()
+	lvl, start := c.logger.opt.execerLevel, time.Now()
 	res, err := driverExecer.Exec(query, args)
 
 	if err != nil {
@@ -156,7 +156,7 @@ func (c *connection) ExecContext(ctx context.Context, query string, args []drive
 
 	logArgs := namedValuesToValues(args)
 	logs := append(c.logData(), c.logger.withQuery(query), c.logger.withArgs(logArgs))
-	lvl, start := LevelInfo, time.Now()
+	lvl, start := c.logger.opt.execerLevel, time.Now()
 	res, err := driverExecerContext.ExecContext(ctx, query, args)
 
 	if err != nil {
@@ -171,13 +171,13 @@ func (c *connection) ExecContext(ctx context.Context, query string, args []drive
 // Query implements driver.Queryer
 // Deprecated: use QueryContext() instead
 func (c *connection) Query(query string, args []driver.Value) (driver.Rows, error) {
-	driverQueryer, ok := c.Conn.(driver.Queryer) // nolint: staticcheck
+	driverQueryer, ok := c.Conn.(driver.Queryer) // nolint // disable static check on deprecated driver method
 	if !ok {
 		return nil, driver.ErrSkip
 	}
 
 	logs := append(c.logData(), c.logger.withQuery(query), c.logger.withArgs(args))
-	lvl, start := LevelInfo, time.Now()
+	lvl, start := c.logger.opt.queryerLevel, time.Now()
 	res, err := driverQueryer.Query(query, args)
 
 	if err != nil {
@@ -198,7 +198,7 @@ func (c *connection) QueryContext(ctx context.Context, query string, args []driv
 
 	logArgs := namedValuesToValues(args)
 	logs := append(c.logData(), c.logger.withQuery(query), c.logger.withArgs(logArgs))
-	lvl, start := LevelInfo, time.Now()
+	lvl, start := c.logger.opt.queryerLevel, time.Now()
 	res, err := driverQueryerContext.QueryContext(ctx, query, args)
 
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.0 h1:DMOzIV76tmoDNE9pX6RSN0aDtCYeCg5VueieJaAo1uw=
-github.com/stretchr/testify v1.5.0/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -45,8 +43,6 @@ go.uber.org/multierr v1.3.0 h1:sFPn2GLc3poCkfrpIXGhBD2X0CMIo4Q/zSULXrj/+uc=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
-go.uber.org/zap v1.13.0 h1:nR6NoDBgAf67s68NhaXbsojM+2gxp3S1hWkHDl27pVU=
-go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.14.0 h1:/pduUoebOeeJzTDFuoMgC6nRkiasr1sBCIEorly7m4o=
 go.uber.org/zap v1.14.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.17.2 h1:RMRHFw2+wF7LO0QqtELQwo8hqSmqISyCJeFeAAuWcRo=
-github.com/rs/zerolog v1.17.2/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
 github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/logger.go
+++ b/logger.go
@@ -24,16 +24,17 @@ const (
 )
 
 // String implement Stringer to convert type Level to string.
+// nolint // disable goconst check
 func (l Level) String() string {
 	switch l {
 	case LevelTrace:
-		return "trace" // nolint: goconst
+		return "trace"
 	case LevelDebug:
-		return "debug" // nolint: goconst
+		return "debug"
 	case LevelInfo:
-		return "info" // nolint: goconst
+		return "info"
 	case LevelError:
-		return "error" // nolint: goconst
+		return "error"
 	default:
 		return fmt.Sprintf("(invalid level): %d", l)
 	}
@@ -103,6 +104,10 @@ func (l *logger) log(ctx context.Context, lvl Level, msg string, start time.Time
 	data := map[string]interface{}{
 		l.opt.timeFieldname:     l.opt.timeFormat.format(time.Now()),
 		l.opt.durationFieldname: l.opt.durationUnit.format(time.Since(start)),
+	}
+
+	if l.opt.includeStartTime {
+		data[l.opt.startTimeFieldname] = l.opt.timeFormat.format(start)
 	}
 
 	if lvl == LevelError {

--- a/options_test.go
+++ b/options_test.go
@@ -222,6 +222,98 @@ func TestWithUIDGenerator(t *testing.T) {
 	})
 }
 
+func TestWithIncludeStartTime(t *testing.T) {
+	t.Run("Default not include", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+
+		assert.False(t, cfg.includeStartTime)
+	})
+
+	t.Run("Set start time flag true", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+		WithIncludeStartTime(true)(cfg)
+		WithStartTimeFieldname("start_time")(cfg)
+		WithTimeFormat(TimeFormatUnix)(cfg)
+
+		assert.True(t, cfg.includeStartTime)
+		assert.Equal(t, "start_time", cfg.startTimeFieldname)
+
+		bl := &bufferTestLogger{}
+		l := &logger{opt: cfg, logger: bl}
+		start := time.Now()
+		l.log(
+			context.TODO(),
+			LevelInfo,
+			"msg",
+			start,
+			nil,
+			testLogger.withUID(cfg.stmtIDFieldname, l.opt.uidGenerator.UniqueID()),
+			testLogger.withQuery("query"),
+			testLogger.withArgs([]driver.Value{}),
+		)
+
+		var content bufLog
+		err := json.Unmarshal(bl.Bytes(), &content)
+		assert.NoError(t, err)
+		assert.Contains(t, content.Data, cfg.startTimeFieldname)
+		assert.Equal(t, float64(start.Unix()), content.Data["start_time"])
+		bl.Reset()
+	})
+}
+
+func TestWithPreparerLevel(t *testing.T) {
+	t.Run("Default value", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+
+		assert.Equal(t, cfg.preparerLevel, LevelInfo)
+	})
+
+	t.Run("Custom value", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+		WithPreparerLevel(LevelDebug)(cfg)
+
+		assert.Equal(t, cfg.preparerLevel, LevelDebug)
+	})
+}
+
+func TestWithQueryerLevel(t *testing.T) {
+	t.Run("Default value", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+
+		assert.Equal(t, cfg.queryerLevel, LevelInfo)
+	})
+
+	t.Run("Custom value", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+		WithQueryerLevel(LevelDebug)(cfg)
+
+		assert.Equal(t, cfg.queryerLevel, LevelDebug)
+	})
+}
+
+func TestWithExecerLevel(t *testing.T) {
+	t.Run("Default value", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+
+		assert.Equal(t, cfg.execerLevel, LevelInfo)
+	})
+
+	t.Run("Custom value", func(t *testing.T) {
+		cfg := &options{}
+		setDefaultOptions(cfg)
+		WithExecerLevel(LevelDebug)(cfg)
+
+		assert.Equal(t, cfg.execerLevel, LevelDebug)
+	})
+}
+
 var uidBtest = newDefaultUIDDGenerator()
 
 func BenchmarkUniqueID(b *testing.B) {

--- a/statement.go
+++ b/statement.go
@@ -42,8 +42,8 @@ func (s *statement) NumInput() int {
 // Exec implements driver.Stmt
 func (s *statement) Exec(args []driver.Value) (driver.Result, error) {
 	logs := append(s.logData(), s.logger.withArgs(args))
-	lvl, start := LevelInfo, time.Now()
-	res, err := s.Stmt.Exec(args) // nolint: staticcheck
+	lvl, start := s.logger.opt.execerLevel, time.Now()
+	res, err := s.Stmt.Exec(args) // nolint // disable static check on deprecated driver method
 
 	if err != nil {
 		lvl = LevelError
@@ -57,8 +57,8 @@ func (s *statement) Exec(args []driver.Value) (driver.Result, error) {
 // Query implements driver.Stmt
 func (s *statement) Query(args []driver.Value) (driver.Rows, error) {
 	logs := append(s.logData(), s.logger.withArgs(args))
-	lvl, start := LevelInfo, time.Now()
-	res, err := s.Stmt.Query(args) // nolint: staticcheck
+	lvl, start := s.logger.opt.queryerLevel, time.Now()
+	res, err := s.Stmt.Query(args) // nolint // disable static check on deprecated driver method
 
 	if err != nil {
 		lvl = LevelError
@@ -78,7 +78,7 @@ func (s *statement) ExecContext(ctx context.Context, args []driver.NamedValue) (
 
 	logArgs := namedValuesToValues(args)
 	logs := append(s.logData(), s.logger.withArgs(logArgs))
-	lvl, start := LevelInfo, time.Now()
+	lvl, start := s.logger.opt.execerLevel, time.Now()
 	res, err := stmtExecer.ExecContext(ctx, args)
 
 	if err != nil {
@@ -99,7 +99,7 @@ func (s *statement) QueryContext(ctx context.Context, args []driver.NamedValue) 
 
 	logArgs := namedValuesToValues(args)
 	logs := append(s.logData(), s.logger.withArgs(logArgs))
-	lvl, start := LevelInfo, time.Now()
+	lvl, start := s.logger.opt.queryerLevel, time.Now()
 	res, err := stmtQueryer.QueryContext(ctx, args)
 
 	if err != nil {
@@ -132,7 +132,7 @@ func (s *statement) CheckNamedValue(nm *driver.NamedValue) error {
 
 // ColumnConverter implements driver.ColumnConverter
 func (s *statement) ColumnConverter(idx int) driver.ValueConverter {
-	// nolint: staticcheck
+	// nolint // disable static check on deprecated driver method
 	if converter, ok := s.Stmt.(driver.ColumnConverter); ok {
 		return converter.ColumnConverter(idx)
 	}

--- a/statement_test.go
+++ b/statement_test.go
@@ -100,6 +100,29 @@ func TestStatement_Exec(t *testing.T) {
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
 	})
+
+	t.Run("Success With Custom Level", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Exec", mock.Anything).Return(&resultMock{}, nil)
+
+		custOpt := *testOpts
+		WithExecerLevel(LevelDebug)(&custOpt)
+		custLogger := *testLogger
+		custLogger.opt = &custOpt
+
+		stmt := &statement{query: q, Stmt: stmtMock, logger: &custLogger, id: custLogger.opt.uidGenerator.UniqueID(), connID: custLogger.opt.uidGenerator.UniqueID()}
+		_, err := stmt.Exec([]driver.Value{"testid"})
+		assert.NoError(t, err)
+
+		var output bufLog
+		err = json.Unmarshal(bufLogger.Bytes(), &output)
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtExec", output.Message)
+		assert.Equal(t, LevelDebug.String(), output.Level)
+		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
+		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
+	})
 }
 
 func TestStatement_Query(t *testing.T) {
@@ -136,6 +159,29 @@ func TestStatement_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "StmtQuery", output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
+		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
+		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
+	})
+
+	t.Run("Success With Custom Level", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Query", mock.Anything).Return(&rowsMock{}, nil)
+
+		custOpt := *testOpts
+		WithQueryerLevel(LevelDebug)(&custOpt)
+		custLogger := *testLogger
+		custLogger.opt = &custOpt
+
+		stmt := &statement{query: q, Stmt: stmtMock, logger: &custLogger, id: custLogger.opt.uidGenerator.UniqueID(), connID: custLogger.opt.uidGenerator.UniqueID()}
+		_, err := stmt.Query([]driver.Value{"testid"})
+		assert.NoError(t, err)
+
+		var output bufLog
+		err = json.Unmarshal(bufLogger.Bytes(), &output)
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtQuery", output.Message)
+		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
 	})
@@ -189,6 +235,29 @@ func TestStatement_ExecContext(t *testing.T) {
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
 	})
+
+	t.Run("Success With Custom Level", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementExecerContextMock{}
+		stmtMock.On("ExecContext", mock.Anything, mock.Anything).Return(&resultMock{}, nil)
+
+		custOpt := *testOpts
+		WithExecerLevel(LevelDebug)(&custOpt)
+		custLogger := *testLogger
+		custLogger.opt = &custOpt
+
+		stmt := &statement{query: q, Stmt: stmtMock, logger: &custLogger, id: custLogger.opt.uidGenerator.UniqueID(), connID: custLogger.opt.uidGenerator.UniqueID()}
+		_, err := stmt.ExecContext(context.TODO(), []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.NoError(t, err)
+
+		var output bufLog
+		err = json.Unmarshal(bufLogger.Bytes(), &output)
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtExecContext", output.Message)
+		assert.Equal(t, LevelDebug.String(), output.Level)
+		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
+		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
+	})
 }
 
 func TestStatement_QueryContext(t *testing.T) {
@@ -236,6 +305,29 @@ func TestStatement_QueryContext(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "StmtQueryContext", output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
+		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
+		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
+	})
+
+	t.Run("Success With Custom Level", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementQueryerContextMock{}
+		stmtMock.On("QueryContext", mock.Anything, mock.Anything).Return(&rowsMock{}, nil)
+
+		custOpt := *testOpts
+		WithQueryerLevel(LevelDebug)(&custOpt)
+		custLogger := *testLogger
+		custLogger.opt = &custOpt
+
+		stmt := &statement{query: q, Stmt: stmtMock, logger: &custLogger, id: custLogger.opt.uidGenerator.UniqueID(), connID: custLogger.opt.uidGenerator.UniqueID()}
+		_, err := stmt.QueryContext(context.TODO(), []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.NoError(t, err)
+
+		var output bufLog
+		err = json.Unmarshal(bufLogger.Bytes(), &output)
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtQueryContext", output.Message)
+		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
 	})


### PR DESCRIPTION
- add options to set default level on preparer, execer and queryer
- add option to include start time on log output
- add option to set custom fieldname for start time