### PR TITLE
Fix NamedValueChecker implemented on conn not used

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -261,7 +261,7 @@ func (c *connection) statement(stmt driver.Stmt, err error, id, query string) (d
 		return stmt, err
 	}
 
-	return &statement{Stmt: stmt, query: query, logger: c.logger, connID: c.id, id: id}, nil
+	return &statement{Stmt: stmt, query: query, logger: c.logger, connID: c.id, conn: c.Conn, id: id}, nil
 }
 
 func (c *connection) rows(res driver.Rows, err error, query string, args []driver.Value) (driver.Rows, error) {

--- a/statement.go
+++ b/statement.go
@@ -17,6 +17,7 @@ type statement struct {
 	query  string
 	logger *logger
 	id     string
+	conn   driver.Conn
 	connID string
 }
 
@@ -115,7 +116,10 @@ func (s *statement) QueryContext(ctx context.Context, args []driver.NamedValue) 
 func (s *statement) CheckNamedValue(nm *driver.NamedValue) error {
 	checker, ok := s.Stmt.(driver.NamedValueChecker)
 	if !ok {
-		return driver.ErrSkip
+		checker, ok = s.conn.(driver.NamedValueChecker)
+		if !ok {
+			return driver.ErrSkip
+		}
 	}
 
 	lvl, start := LevelTrace, time.Now()


### PR DESCRIPTION
https://github.com/golang/go/blob/0e85fd7561de869add933801c531bf25dee9561c/src/database/sql/convert.go#L129

NamedValueChecker also implemented on connection, and above code fallbacks to it when statement does not implement it.
This PR implements same behavior.