### PR TITLE
feat: to use const variables at all codes

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -95,7 +95,7 @@ func TestConnection_Prepare(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Prepare", output.Message)
+		assert.Equal(t, MessagePrepare, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
@@ -121,7 +121,7 @@ func TestConnection_Prepare(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Prepare", output.Message)
+		assert.Equal(t, MessagePrepare, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
@@ -140,7 +140,7 @@ func TestConnection_Close(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Close", output.Message)
+		assert.Equal(t, MessageClose, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
@@ -156,7 +156,7 @@ func TestConnection_Close(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Close", output.Message)
+		assert.Equal(t, MessageClose, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
 	})
@@ -189,7 +189,7 @@ func TestConnection_BeginTx(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "BeginTx", output.Message)
+		assert.Equal(t, MessageBeginTx, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
 		assert.NotEmpty(t, output.Data[testOpts.txIDFieldname])
@@ -211,7 +211,7 @@ func TestConnection_BeginTx(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "BeginTx", output.Message)
+		assert.Equal(t, MessageBeginTx, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
 		assert.NotEmpty(t, output.Data[testOpts.txIDFieldname])
@@ -242,7 +242,7 @@ func TestConnection_PrepareContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "PrepareContext", output.Message)
+		assert.Equal(t, MessagePrepareContext, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -264,7 +264,7 @@ func TestConnection_PrepareContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "PrepareContext", output.Message)
+		assert.Equal(t, MessagePrepareContext, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
@@ -290,7 +290,7 @@ func TestConnection_PrepareContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "PrepareContext", output.Message)
+		assert.Equal(t, MessagePrepareContext, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
@@ -317,7 +317,7 @@ func TestConnection_Ping(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Ping", output.Message)
+		assert.Equal(t, MessagePing, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
@@ -333,7 +333,7 @@ func TestConnection_Ping(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Ping", output.Message)
+		assert.Equal(t, MessagePing, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
 	})
@@ -365,7 +365,7 @@ func TestConnection_Exec(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Exec", output.Message)
+		assert.Equal(t, MessageExec, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -385,7 +385,7 @@ func TestConnection_Exec(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Exec", output.Message)
+		assert.Equal(t, MessageExec, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -410,7 +410,7 @@ func TestConnection_Exec(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Exec", output.Message)
+		assert.Equal(t, MessageExec, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -442,7 +442,7 @@ func TestConnection_ExecContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "ExecContext", output.Message)
+		assert.Equal(t, MessageExecContext, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -463,7 +463,7 @@ func TestConnection_ExecContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "ExecContext", output.Message)
+		assert.Equal(t, MessageExecContext, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -488,7 +488,7 @@ func TestConnection_ExecContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "ExecContext", output.Message)
+		assert.Equal(t, MessageExecContext, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -522,7 +522,7 @@ func TestConnection_Query(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Query", output.Message)
+		assert.Equal(t, MessageQuery, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -543,7 +543,7 @@ func TestConnection_Query(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Query", output.Message)
+		assert.Equal(t, MessageQuery, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -568,7 +568,7 @@ func TestConnection_Query(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Query", output.Message)
+		assert.Equal(t, MessageQuery, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -601,7 +601,7 @@ func TestConnection_QueryContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "QueryContext", output.Message)
+		assert.Equal(t, MessageQueryContext, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -622,7 +622,7 @@ func TestConnection_QueryContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "QueryContext", output.Message)
+		assert.Equal(t, MessageQueryContext, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -647,7 +647,7 @@ func TestConnection_QueryContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "QueryContext", output.Message)
+		assert.Equal(t, MessageQueryContext, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -675,7 +675,7 @@ func TestConnection_ResetSession(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "ResetSession", output.Message)
+		assert.Equal(t, MessageResetSession, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])
 	})
@@ -709,7 +709,7 @@ func TestConnection_CheckNamedValue(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "CheckNamedValue", output.Message)
+		assert.Equal(t, MessageCheckNamedValue, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.NotEmpty(t, output.Data[testOpts.connIDFieldname])
 		assert.Equal(t, conn.id, output.Data[testOpts.connIDFieldname])

--- a/connector.go
+++ b/connector.go
@@ -19,13 +19,14 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	start, id := time.Now(), c.logger.opt.uidGenerator.UniqueID()
 	logID := c.logger.withUID(c.logger.opt.connIDFieldname, id)
 	conn, err := c.driver.Open(c.dsn)
+	msg := MessageConnect
 
 	if err != nil {
-		c.logger.log(ctx, LevelError, "Connect", start, err, logID)
+		c.logger.log(ctx, LevelError, msg, start, err, logID)
 		return nil, err
 	}
 
-	c.logger.log(ctx, LevelDebug, "Connect", start, err, logID)
+	c.logger.log(ctx, LevelDebug, msg, start, err, logID)
 
 	return &connection{Conn: conn, logger: c.logger, id: id}, nil
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -22,7 +22,7 @@ func TestConnector_Connect(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Connect", output.Message)
+		assert.Equal(t, MessageConnect, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.NotEmpty(t, output.Data[testOpts.connIDFieldname])
 	})
@@ -38,7 +38,7 @@ func TestConnector_Connect(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Connect", output.Message)
+		assert.Equal(t, MessageConnect, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.NotEmpty(t, output.Data[testOpts.connIDFieldname])
 	})

--- a/database_test.go
+++ b/database_test.go
@@ -37,7 +37,7 @@ func TestOpenDriver(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Connect", output.Message)
+		assert.Equal(t, MessageConnect, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Contains(t, output.Data, "errtest")
 	})

--- a/message.go
+++ b/message.go
@@ -1,0 +1,67 @@
+package sqldblogger
+
+const (
+	MessageCommit              = "Commit"
+	MessageRollback            = "Rollback"
+	MessageResultLastInsertId  = "ResultLastInsertId"
+	MessageResultRowsAffected  = "ResultRowsAffected"
+	MessageBegin               = "Begin"
+	MessagePrepareContext      = "PrepareContext"
+	MessagePrepare             = "Prepare"
+	MessageClose               = "Close"
+	MessageConnect             = "Connect"
+	MessageBeginTx             = "BeginTx"
+	MessagePing                = "Ping"
+	MessageExec                = "Exec"
+	MessageExecContext         = "ExecContext"
+	MessageQuery               = "Query"
+	MessageQueryContext        = "QueryContext"
+	MessageResetSession        = "ResetSession"
+	MessageCheckNamedValue     = "CheckNamedValue"
+	MessageRowsClose           = "RowsClose"
+	MessageRowsNext            = "RowsNext"
+	MessageRowsNextResultSet   = "RowsNextResultSet"
+	MessageStmtClose           = "StmtClose"
+	MessageStmtExec            = "StmtExec"
+	MessageStmtQuery           = "StmtQuery"
+	MessageStmtCheckNamedValue = "StmtCheckNamedValue"
+	MessageStmtQueryContext    = "StmtQueryContext"
+	MessageStmtExecContext     = "StmtExecContext"
+)
+
+var mapMsgToLevel = map[string]Level{
+	MessageCommit:              LevelDebug,
+	MessageRollback:            LevelDebug,
+	MessageResultLastInsertId:  LevelTrace,
+	MessageResultRowsAffected:  LevelTrace,
+	MessageBegin:               LevelDebug,
+	MessagePrepare:             LevelInfo,
+	MessagePrepareContext:      LevelInfo,
+	MessageClose:               LevelDebug,
+	MessageBeginTx:             LevelDebug,
+	MessagePing:                LevelDebug,
+	MessageExec:                LevelDebug,
+	MessageExecContext:         LevelDebug,
+	MessageQuery:               LevelInfo,
+	MessageQueryContext:        LevelDebug,
+	MessageResetSession:        LevelTrace,
+	MessageCheckNamedValue:     LevelTrace,
+	MessageRowsClose:           LevelTrace,
+	MessageRowsNext:            LevelTrace,
+	MessageRowsNextResultSet:   LevelTrace,
+	MessageStmtClose:           LevelDebug,
+	MessageStmtExec:            LevelDebug,
+	MessageStmtExecContext:     LevelDebug,
+	MessageStmtQuery:           LevelInfo,
+	MessageStmtQueryContext:    LevelInfo,
+	MessageStmtCheckNamedValue: LevelTrace,
+}
+
+func getDefaultLevelByMessage(msg string, level *Level) Level {
+	if level != nil {
+		return *level
+	} else if lvl, ok := mapMsgToLevel[msg]; ok {
+		return lvl
+	}
+	return LevelTrace
+}

--- a/result.go
+++ b/result.go
@@ -18,28 +18,30 @@ type result struct {
 
 // LastInsertId implement driver.Result
 func (r *result) LastInsertId() (int64, error) {
-	lvl, start := LevelTrace, time.Now()
+	msg := MessageResultLastInsertId
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	id, err := r.Result.LastInsertId()
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	r.logger.log(context.Background(), lvl, "ResultLastInsertId", start, err, r.logData()...)
+	r.logger.log(context.Background(), lvl, msg, start, err, r.logData()...)
 
 	return id, err
 }
 
 // RowsAffected implement driver.Result
 func (r *result) RowsAffected() (int64, error) {
-	lvl, start := LevelTrace, time.Now()
+	msg := MessageResultRowsAffected
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	num, err := r.Result.RowsAffected()
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	r.logger.log(context.Background(), lvl, "ResultRowsAffected", start, err, r.logData()...)
+	r.logger.log(context.Background(), lvl, msg, start, err, r.logData()...)
 
 	return num, err
 }

--- a/rows.go
+++ b/rows.go
@@ -32,14 +32,15 @@ func (r *rows) Columns() []string {
 
 // Close implement driver.Rows
 func (r *rows) Close() error {
-	lvl, start := LevelTrace, time.Now()
+	msg := MessageRowsClose
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := r.Rows.Close()
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	r.logger.log(context.Background(), lvl, "RowsClose", start, err, r.logData()...)
+	r.logger.log(context.Background(), lvl, msg, start, err, r.logData()...)
 
 	return err
 }
@@ -54,14 +55,15 @@ func (r *rows) Next(dest []driver.Value) error {
 		logs = append(logs, r.logger.withKeyArgs("rows_dest", dest))
 	}
 
-	lvl, start := LevelTrace, time.Now()
+	msg := MessageRowsNext
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := r.Rows.Next(dest)
 
 	if err != nil && err != io.EOF {
 		lvl = LevelError
 	}
 
-	r.logger.log(context.Background(), lvl, "RowsNext", start, err, logs...)
+	r.logger.log(context.Background(), lvl, msg, start, err, logs...)
 
 	return err
 }
@@ -82,14 +84,15 @@ func (r *rows) NextResultSet() error {
 		return io.EOF
 	}
 
-	lvl, start := LevelTrace, time.Now()
+	msg := MessageRowsNextResultSet
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := rs.NextResultSet()
 
 	if err != nil && err != io.EOF {
 		lvl = LevelError
 	}
 
-	r.logger.log(context.Background(), lvl, "RowsNextResultSet", start, err, r.logData()...)
+	r.logger.log(context.Background(), lvl, msg, start, err, r.logData()...)
 
 	return err
 }

--- a/statement.go
+++ b/statement.go
@@ -22,14 +22,15 @@ type statement struct {
 
 // Close implements driver.Stmt
 func (s *statement) Close() error {
-	lvl, start := LevelDebug, time.Now()
+	msg := MessageStmtClose
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := s.Stmt.Close()
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	s.logger.log(context.Background(), lvl, "StmtClose", start, err, s.logData()...)
+	s.logger.log(context.Background(), lvl, msg, start, err, s.logData()...)
 
 	return err
 }
@@ -42,14 +43,15 @@ func (s *statement) NumInput() int {
 // Exec implements driver.Stmt
 func (s *statement) Exec(args []driver.Value) (driver.Result, error) {
 	logs := append(s.logData(), s.logger.withArgs(args))
-	lvl, start := s.logger.opt.execerLevel, time.Now()
+	msg := MessageStmtExec
+	lvl, start := getDefaultLevelByMessage(msg, &s.logger.opt.execerLevel), time.Now()
 	res, err := s.Stmt.Exec(args) // nolint // disable static check on deprecated driver method
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	s.logger.log(context.Background(), lvl, "StmtExec", start, err, logs...)
+	s.logger.log(context.Background(), lvl, msg, start, err, logs...)
 
 	return s.result(res, err, args)
 }
@@ -57,14 +59,15 @@ func (s *statement) Exec(args []driver.Value) (driver.Result, error) {
 // Query implements driver.Stmt
 func (s *statement) Query(args []driver.Value) (driver.Rows, error) {
 	logs := append(s.logData(), s.logger.withArgs(args))
-	lvl, start := s.logger.opt.queryerLevel, time.Now()
+	msg := MessageStmtQuery
+	lvl, start := getDefaultLevelByMessage(msg, &s.logger.opt.queryerLevel), time.Now()
 	res, err := s.Stmt.Query(args) // nolint // disable static check on deprecated driver method
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	s.logger.log(context.Background(), lvl, "StmtQuery", start, err, logs...)
+	s.logger.log(context.Background(), lvl, msg, start, err, logs...)
 
 	return s.rows(res, err, args)
 }
@@ -78,14 +81,15 @@ func (s *statement) ExecContext(ctx context.Context, args []driver.NamedValue) (
 
 	logArgs := namedValuesToValues(args)
 	logs := append(s.logData(), s.logger.withArgs(logArgs))
-	lvl, start := s.logger.opt.execerLevel, time.Now()
+	msg := MessageStmtExecContext
+	lvl, start := getDefaultLevelByMessage(msg, &s.logger.opt.execerLevel), time.Now()
 	res, err := stmtExecer.ExecContext(ctx, args)
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	s.logger.log(ctx, lvl, "StmtExecContext", start, err, logs...)
+	s.logger.log(ctx, lvl, msg, start, err, logs...)
 
 	return s.result(res, err, logArgs)
 }
@@ -99,14 +103,15 @@ func (s *statement) QueryContext(ctx context.Context, args []driver.NamedValue) 
 
 	logArgs := namedValuesToValues(args)
 	logs := append(s.logData(), s.logger.withArgs(logArgs))
-	lvl, start := s.logger.opt.queryerLevel, time.Now()
+	msg := MessageStmtQueryContext
+	lvl, start := getDefaultLevelByMessage(msg, &s.logger.opt.queryerLevel), time.Now()
 	res, err := stmtQueryer.QueryContext(ctx, args)
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	s.logger.log(ctx, lvl, "StmtQueryContext", start, err, logs...)
+	s.logger.log(ctx, lvl, msg, start, err, logs...)
 
 	return s.rows(res, err, logArgs)
 }
@@ -118,14 +123,15 @@ func (s *statement) CheckNamedValue(nm *driver.NamedValue) error {
 		return driver.ErrSkip
 	}
 
-	lvl, start := LevelTrace, time.Now()
+	msg := MessageStmtCheckNamedValue
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := checker.CheckNamedValue(nm)
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	s.logger.log(context.Background(), lvl, "StmtCheckNamedValue", start, err, s.logData()...)
+	s.logger.log(context.Background(), lvl, msg, start, err, s.logData()...)
 
 	return err
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -23,7 +23,7 @@ func TestStatement_Close(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtClose", output.Message)
+		assert.Equal(t, MessageStmtClose, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -43,7 +43,7 @@ func TestStatement_Close(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtClose", output.Message)
+		assert.Equal(t, MessageStmtClose, output.Message)
 		assert.NotContains(t, output.Data, testOpts.errorFieldname)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, stmt.connID, output.Data[testOpts.connIDFieldname])
@@ -74,7 +74,7 @@ func TestStatement_Exec(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtExec", output.Message)
+		assert.Equal(t, MessageStmtExec, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -93,7 +93,7 @@ func TestStatement_Exec(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtExec", output.Message)
+		assert.Equal(t, MessageStmtExec, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -116,7 +116,7 @@ func TestStatement_Exec(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtExec", output.Message)
+		assert.Equal(t, MessageStmtExec, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -136,7 +136,7 @@ func TestStatement_Query(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtQuery", output.Message)
+		assert.Equal(t, MessageStmtQuery, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -155,7 +155,7 @@ func TestStatement_Query(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtQuery", output.Message)
+		assert.Equal(t, MessageStmtQuery, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -178,7 +178,7 @@ func TestStatement_Query(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtQuery", output.Message)
+		assert.Equal(t, MessageStmtQuery, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -209,7 +209,7 @@ func TestStatement_ExecContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtExecContext", output.Message)
+		assert.Equal(t, MessageStmtExecContext, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -228,7 +228,7 @@ func TestStatement_ExecContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtExecContext", output.Message)
+		assert.Equal(t, MessageStmtExecContext, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -251,7 +251,7 @@ func TestStatement_ExecContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtExecContext", output.Message)
+		assert.Equal(t, MessageStmtExecContext, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -282,7 +282,7 @@ func TestStatement_QueryContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtQueryContext", output.Message)
+		assert.Equal(t, MessageStmtQueryContext, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.Data[testOpts.errorFieldname])
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
@@ -301,7 +301,7 @@ func TestStatement_QueryContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtQueryContext", output.Message)
+		assert.Equal(t, MessageStmtQueryContext, output.Message)
 		assert.Equal(t, LevelInfo.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -324,7 +324,7 @@ func TestStatement_QueryContext(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "StmtQueryContext", output.Message)
+		assert.Equal(t, MessageStmtQueryContext, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 		assert.Equal(t, q, output.Data[testOpts.sqlQueryFieldname])
 		assert.Equal(t, []interface{}{"testid"}, output.Data[testOpts.sqlArgsFieldname])
@@ -371,7 +371,7 @@ func TestStatement_CheckNamedValue(t *testing.T) {
 		err = json.Unmarshal(bufLogger.Bytes(), &stmtOutput)
 		assert.NoError(t, err)
 		assert.Equal(t, LevelError.String(), stmtOutput.Level)
-		assert.Equal(t, "StmtCheckNamedValue", stmtOutput.Message)
+		assert.Equal(t, MessageStmtCheckNamedValue, stmtOutput.Message)
 		assert.NotEmpty(t, stmtOutput.Data[testOpts.stmtIDFieldname])
 		assert.NotEmpty(t, stmtOutput.Data[testOpts.connIDFieldname])
 	})

--- a/transaction.go
+++ b/transaction.go
@@ -15,28 +15,30 @@ type transaction struct {
 
 // Commit implement driver.Tx
 func (tx *transaction) Commit() error {
-	lvl, start := LevelDebug, time.Now()
+	msg := MessageCommit
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := tx.Tx.Commit()
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	tx.logger.log(context.Background(), lvl, "Commit", start, err, tx.logData()...)
+	tx.logger.log(context.Background(), lvl, msg, start, err, tx.logData()...)
 
 	return err
 }
 
 // Rollback implement driver.Tx
 func (tx *transaction) Rollback() error {
-	lvl, start := LevelDebug, time.Now()
+	msg := MessageRollback
+	lvl, start := getDefaultLevelByMessage(msg, nil), time.Now()
 	err := tx.Tx.Rollback()
 
 	if err != nil {
 		lvl = LevelError
 	}
 
-	tx.logger.log(context.Background(), lvl, "Rollback", start, err, tx.logData()...)
+	tx.logger.log(context.Background(), lvl, msg, start, err, tx.logData()...)
 
 	return err
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -21,7 +21,7 @@ func TestTransaction_Commit(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Commit", output.Message)
+		assert.Equal(t, MessageCommit, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 	})
 
@@ -36,7 +36,7 @@ func TestTransaction_Commit(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Commit", output.Message)
+		assert.Equal(t, MessageCommit, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 	})
 }
@@ -53,7 +53,7 @@ func TestTransaction_Rollback(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Rollback", output.Message)
+		assert.Equal(t, MessageRollback, output.Message)
 		assert.Equal(t, LevelError.String(), output.Level)
 	})
 
@@ -68,7 +68,7 @@ func TestTransaction_Rollback(t *testing.T) {
 		var output bufLog
 		err = json.Unmarshal(bufLogger.Bytes(), &output)
 		assert.NoError(t, err)
-		assert.Equal(t, "Rollback", output.Message)
+		assert.Equal(t, MessageRollback, output.Message)
 		assert.Equal(t, LevelDebug.String(), output.Level)
 	})
 }


### PR DESCRIPTION
It's hard to recognize which actions is has a level between [queryer, execer, preparer].

DB 'action' messages are needed to collect in a file. Also, log levels is separated by actions.
