### PR TITLE
zerologadapter: Pass the context to logger

### DIFF
--- a/logadapter/zerologadapter/go.mod
+++ b/logadapter/zerologadapter/go.mod
@@ -3,7 +3,7 @@ module github.com/simukti/sqldb-logger/logadapter/zerologadapter
 go 1.17
 
 require (
-	github.com/rs/zerolog v1.28.0
+	github.com/rs/zerolog v1.30.0
 	github.com/simukti/sqldb-logger v0.0.0-20230108154142-840120f68bea
 	github.com/stretchr/testify v1.8.1
 )

--- a/logadapter/zerologadapter/go.sum
+++ b/logadapter/zerologadapter/go.sum
@@ -1,4 +1,4 @@
-github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -20,9 +20,9 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
-github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.30.0 h1:SymVODrcRsaRaSInD9yQtKbtWqwsfoPcRff/oRXLj4c=
+github.com/rs/zerolog v1.30.0/go.mod h1:/tk+P47gFdPXq4QYjvCmT5/Gsug2nagsFWBWhAiSi1w=
 github.com/simukti/sqldb-logger v0.0.0-20230108154142-840120f68bea h1:MygiYxbZHQAGOsZmrIiytjLhPLwww1xcdXzPORrOrLM=
 github.com/simukti/sqldb-logger v0.0.0-20230108154142-840120f68bea/go.mod h1:ztTX0ctjRZ1wn9OXrzhonvNmv43yjFUXJYJR95JQAJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/logadapter/zerologadapter/logger.go
+++ b/logadapter/zerologadapter/logger.go
@@ -19,7 +19,7 @@ func New(logger zerolog.Logger) sqldblogger.Logger {
 
 // Log implement sqldblogger.Logger and log it as is.
 // To use context.Context values, please copy this file and adjust to your needs.
-func (zl *zerologAdapter) Log(_ context.Context, level sqldblogger.Level, msg string, data map[string]interface{}) {
+func (zl *zerologAdapter) Log(ctx context.Context, level sqldblogger.Level, msg string, data map[string]interface{}) {
 	var lvl zerolog.Level
 
 	switch level {
@@ -35,5 +35,5 @@ func (zl *zerologAdapter) Log(_ context.Context, level sqldblogger.Level, msg st
 		lvl = zerolog.DebugLevel
 	}
 
-	zl.logger.WithLevel(lvl).Fields(data).Msg(msg)
+	zl.logger.WithLevel(lvl).Ctx(ctx).Fields(data).Msg(msg)
 }


### PR DESCRIPTION
- Pass the context to the logger to be used by hooks.
- Update test case with a hook to read value from the context.
- Bump zerolog to v.1.30.0 to use `zerolog.Event.Ctx`.

Edit: This is useful to retrieve values from the context in hooks to include in logs, such as a trace ID.